### PR TITLE
Hide empty TVs tabs

### DIFF
--- a/manager/templates/default/resource/sections/tvs.tpl
+++ b/manager/templates/default/resource/sections/tvs.tpl
@@ -94,6 +94,13 @@ Ext.onReady(function() {
             ,id: 'modx-resource-vtabs-header'
             ,html: MODx.config.show_tv_categories_header == true ? '<h4 id="modx-resource-vtabs-header-title">'+_('categories')+'</h4>' : ''
         }
+        ,listeners:{beforeadd:function(that,component,index){
+        	if(Ext.get(component.contentEl).child('.modx-tv')==null)return false;
+        },afterrender:function(that){
+        	if(that.items.length===0){
+        		Ext.getCmp("modx-resource-tabs").hideTabStripItem('modx-panel-resource-tv');
+        	}
+        }}
     });
     {/literal}{/if}
 


### PR DESCRIPTION
### What does it do?
Do not add emty TVs category tab on resource and hide TV-tab if is empty

### Why is it needed?
If you move TV by form custumization or by plugins, some TV categories or tab with TVs may be empty after.
BEFORE:
![image 001](https://user-images.githubusercontent.com/26022362/31816373-c1802250-b598-11e7-93b8-3c833be6f8c6.jpg)
AFTER:
![image 002](https://user-images.githubusercontent.com/26022362/31816380-caacb618-b598-11e7-8ad2-eb175d19a529.jpg)

### Related issue(s)/PR(s)

